### PR TITLE
Add redirect for Cure Acceleration Act

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -23,6 +23,12 @@ const redirects = [
     permanent: true,
     description: "Redirect to health savings sharing documentation",
   },
+  {
+    source: "/cure-acceleration-act",
+    destination: "/docs/cure-acceleration-act",
+    permanent: true,
+    description: "Redirect to Cure Acceleration Act",
+  },
   // Add more redirects here
   // Make sure to add the source path to the matcher array below 👇
 ] as const
@@ -110,5 +116,6 @@ export const config = {
     "/signup",
     "/dfda",
     "/dfda/:path*",
+    "/cure-acceleration-act",
   ],
 }


### PR DESCRIPTION
This commit introduces a new redirect from "/cure-acceleration-act" to "/docs/cure-acceleration-act" with a permanent status. It also ensures the new source path is included in the matcher array to handle requests properly.

## Summary by Sourcery

New Features:
- Redirect requests from "/cure-acceleration-act" to "/docs/cure-acceleration-act".